### PR TITLE
Allow tracking composite widgets

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -61,12 +61,14 @@
   background: var(--theia-layout-color0);
 }
 
-.p-TabBar.theia-app-left .p-TabBar-tab.theia-mod-active {
+.p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current.theia-mod-active {
   border-left-color: var(--theia-accent-color2);
+  border-top-color: transparent;
 }
 
-.p-TabBar.theia-app-right .p-TabBar-tab.theia-mod-active {
+.p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current.theia-mod-active {
   border-right-color: var(--theia-accent-color2);
+  border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tab:hover {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -63,7 +63,7 @@
 }
 
 /* This is the main application level active tab: only 1 exists. */
-.p-TabBar.theia-app-centers .p-TabBar-tab.theia-mod-active {
+.p-TabBar .p-TabBar-tab.p-mod-current.theia-mod-active {
   border-top-color: var(--theia-accent-color2);
 }
 

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -18,7 +18,7 @@ import { injectable, postConstruct, } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { RecursivePartial, Emitter, Event } from '@theia/core/lib/common';
 import { WidgetOpenHandler, WidgetOpenerOptions } from '@theia/core/lib/browser';
-import { EditorWidget, EditorWidgetProvider } from './editor-widget';
+import { EditorWidget } from './editor-widget';
 import { Range, Position } from './editor';
 import { EditorWidgetFactory } from './editor-widget-factory';
 
@@ -69,13 +69,7 @@ export class EditorManager extends WidgetOpenHandler<EditorWidget> {
     }
     protected updateActiveEditor(): void {
         const widget = this.shell.activeWidget;
-        if (widget instanceof EditorWidget) {
-            this.setActiveEditor(widget);
-        } else if (EditorWidgetProvider.is(widget)) {
-            this.setActiveEditor(widget.getEditorWidget());
-        } else {
-            this.setActiveEditor(undefined);
-        }
+        this.setActiveEditor(widget instanceof EditorWidget ? widget : undefined);
     }
 
     protected _currentEditor: EditorWidget | undefined;
@@ -96,8 +90,6 @@ export class EditorManager extends WidgetOpenHandler<EditorWidget> {
         const widget = this.shell.currentWidget;
         if (widget instanceof EditorWidget) {
             this.setCurrentEditor(widget);
-        } else if (EditorWidgetProvider.is(widget)) {
-            this.setCurrentEditor(widget.getEditorWidget());
         } else if (!this._currentEditor || !this._currentEditor.isVisible) {
             this.setCurrentEditor(undefined);
         }

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -19,15 +19,6 @@ import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable } fr
 import URI from '@theia/core/lib/common/uri';
 import { TextEditor } from './editor';
 
-export interface EditorWidgetProvider {
-    getEditorWidget(): EditorWidget;
-}
-export namespace EditorWidgetProvider {
-    export function is(provider: object | undefined): provider is EditorWidgetProvider {
-        return !!provider && 'getEditorWidget' in provider;
-    }
-}
-
 export class EditorWidget extends BaseWidget implements SaveableSource, Navigatable {
 
     constructor(


### PR DESCRIPTION
I removed the EditorProvider from the editor manager in favor of adding a similar concept on the level of the focus tracker on the application shell.